### PR TITLE
Make Python3 compatible

### DIFF
--- a/mf2outline.py
+++ b/mf2outline.py
@@ -257,7 +257,7 @@ def bezierjoin(first,second):
 def bezierarc_new(c,s,e,r):
 	sangle = vecangle((1,0),s) + 360  # this is very important!
 	eangle = sangle + vecangle(s,e) # this is very important!
-	print sangle,eangle,vecangle(s,e)
+	print(sangle,eangle,vecangle(s,e))
 	# if < 90 degree and no extremum inbetween:
 	if abs(eangle-sangle) <= 90.001 and (sangle // 90 == eangle // 90 \
 	or sangle % 90 < 1e-6 or eangle % 90 < 1e-6):

--- a/mf2outline.py
+++ b/mf2outline.py
@@ -1777,7 +1777,7 @@ if __name__ == "__main__":
 		currentencoding = font.encoding
 		font.encoding = "unicode" #add space for non-TeX use
 		font.createChar(32)
-		font[32].width = font_normal_space
+		font[32].width = int(font_normal_space)
 		font.encoding = currentencoding
 	
 	if not args.raw:


### PR DESCRIPTION
Fixes 2 issues with python3:

1. Required parenthesis for `print`
2. https://github.com/linusromer/mf2outline/issues/5